### PR TITLE
eliminate deprecation warning

### DIFF
--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/datasets.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/datasets.py
@@ -3,7 +3,7 @@ import pathlib
 import sys
 
 import joblib
-from sklearn.datasets.base import Bunch
+from sklearn.utils import Bunch
 from sklearn.model_selection import train_test_split
 from functools import partial
 


### PR DESCRIPTION
sklearn.datasets.base is deprecated. Change reference to where it actually lives