### PR TITLE
Easydata 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,30 @@
 
 # Cookiecutter EasyData
 
-_A flexible (but opinionated) toolkit for doing and sharing reproducible data science._
+_A python framework and git gemplate for data scientists, teams, and workshop organizers
+aimed at making your data science **reproducible**__
 
-EasyData started life as an experimental fork of
-[cookiecutter-data-science](http://drivendata.github.io/cookiecutter-data-science/)
-where we could try out ideas before proposing them as fixes to the upstream branch. It has grown into its own toolkit for implementing a reproducible data science workflow, and is the basis of our [Bus Number](https://github.com/hackalog/bus_number/) tutorial on **Reproducible Data Science**.
+For most of us, data science is 5% science, 60% data cleaning, and 35%
+IT hell.  Easydata focuses on delivering
+* reproducible python environments,
+* reproducible datasets, and
+* reproducible workflows
+in order to get you up and running with your data science quickly, and reproducibly.
 
-### Tutorial
-For a tutorial on making use of a previous version of this framework (available via the `bus_number` branch), visit:
-  https://github.com/hackalog/bus_number/
+## What is Easydata?
+
+Easydata is a python cookiecutter for building custom data science git repos that provides:
+* An **opinionated workflow** for collaboration, storytelling,
+* A **python framework** to support this workflow
+* A **makefile wrapper** for conda and pip environment management
+* prebuilt **dataset recipes*, and
+* a vast library of training materials and documentation around doing reproducible data science.
+
+Easydata is **not**
+* an ETL tooklit
+* A data analysis pipreline
+* a containerization solution, or
+* a prescribed data format.
 
 
 ### Requirements to use this cookiecutter template:
@@ -22,15 +37,12 @@ For a tutorial on making use of a previous version of this framework (available 
 
  - [Cookiecutter Python package](http://cookiecutter.readthedocs.org/en/latest/installation.html) >= 1.4.0: This can be installed with pip by or conda depending on how you manage your Python packages:
 
-``` bash
-$ pip install cookiecutter
-```
+once you've installed anaconda, you can install the remaining requirements (including cookiecutter) by doing:
 
-or
-
-``` bash
-$ conda config --add channels conda-forge
-$ conda install cookiecutter
+```bash
+conda create -n easydata python=3
+conda activate easydata
+python -m pip install -f requirements.txt
 ```
 
 
@@ -54,6 +66,8 @@ The directory structure of your new project looks like this:
 * `catalog`
   * Data catalog. This is where config information such as data sources
     and data transformations are saved
+  * `catalog/config.ini`
+     * Local Data Store. This configuration file is for local data only, and is never checked into the repo.
 * `data`
     * Data directory. often symlinked to a filesystem with lots of space
     * `data/raw`
@@ -64,6 +78,8 @@ The directory structure of your new project looks like this:
         * The final, canonical data sets for modeling.
 * `docs`
     * A default Sphinx project; see sphinx-doc.org for details
+* `framework-docs`
+    * Markdown documentation for using Easydata
 * `models`
     * Trained and serialized models, model predictions, or model summaries
     * `models/trained`
@@ -86,6 +102,8 @@ The directory structure of your new project looks like this:
         * Generated summary information to be used in reporting
 * `environment.yml`
     * (if using conda) The YAML file for reproducing the analysis environment
+* `environment.(platform).lock.yml`
+    * resolved versions, result of processing `environment.yml`
 * `setup.py`
     * Turns contents of `MODULE_NAME` into a
     pip-installable python module  (`pip install -e .`) so it can be
@@ -95,15 +113,9 @@ The directory structure of your new project looks like this:
     * `MODULE_NAME/__init__.py`
         * Makes MODULE_NAME a Python module
     * `MODULE_NAME/data`
-        * Scripts to fetch or generate data. In particular:
-        * `MODULE_NAME/data/make_dataset.py`
-            * Run with `python -m MODULE_NAME.data.make_dataset fetch`
-            or  `python -m MODULE_NAME.data.make_dataset process`
+        * code to fetch raw data and generate Datasets from them
     * `MODULE_NAME/analysis`
-        * Scripts to turn datasets into output products
-    * `MODULE_NAME/models`
-        * Scripts to train models and then use trained models to make predictions.
-        e.g. `predict_model.py`, `train_model.py`
+        * code to turn datasets into output products
 * `tox.ini`
     * tox file with settings for running tox; see tox.testrun.org
 
@@ -128,3 +140,8 @@ In case you need to delete the environment later:
 conda deactivate
 make delete_environment
 ```
+
+
+## History
+Early versions of Easydata were based on
+[cookiecutter-data-science](http://drivendata.github.io/cookiecutter-data-science/).

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,10 +1,12 @@
 {
     "project_name": "project_name",
     "repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
+    "default_branch": ["master", "main"],
     "module_name": "src",
     "author_name": "Your name (or your organization/company/team)",
     "description": "A short description of this project.",
     "open_source_license": ["MIT", "BSD-2-Clause", "Proprietary"],
     "python_version": ["3.7", "3.6", "latest", "3.8"],
-    "conda_path": "~/anaconda3/bin/conda"
+    "conda_path": "~/anaconda3/bin/conda",
+    "upstream_location": ["github.com", "gitlab.com", "bitbucket.org", "your-custom-repo"]
 }

--- a/{{ cookiecutter.repo_name }}/.post-create-environment.txt
+++ b/{{ cookiecutter.repo_name }}/.post-create-environment.txt
@@ -1,3 +1,8 @@
+
+Now would be a good time to initialize a git repo; i.e.
+>>> git init
+>>> git add .
+>>> git commit -m 'initial import'
 >>> git branch easydata    # tag for future easydata upgrades
 
 NOTE: By default, raw data is installed and unpacked in the

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -71,17 +71,14 @@ clean:
 	rm -f .make.*
 
 .PHONY: clean_interim
-## Delete all interim (DataSource) files
 clean_interim:
 	rm -rf data/interim/*
 
 .PHONY: clean_raw
-## Delete the raw downloads directory
 clean_raw:
 	rm -f data/raw/*
 
 .PHONY: clean_processed
-## Delete all processed datasets
 clean_processed:
 	rm -f data/processed/*
 

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -27,11 +27,9 @@ unfinished:
 #
 
 .PHONY: data
-## convert raw datasets into fully processed datasets
 data: transform_data
 
 .PHONY: sources
-## Fetch, Unpack, and Process raw DataSources
 sources: process_sources
 
 .PHONY: fetch_sources
@@ -56,7 +54,6 @@ process_sources: .make.process_sources
 	touch .make.process_sources
 
 .PHONY: transform_data
-## Apply Transformations to produce fully processed Datsets
 transform_data: .make.transform_data
 
 .make.transform_data: .make.process_sources
@@ -100,7 +97,7 @@ lint:
 	flake8 $(MODULE_NAME)
 
 .PHONY: debug
-## Give a report on current status
+## dump useful debugging information to $(DEBUG_FILE)
 debug:
 	@echo "\n\n======================"
 	@echo "\nPlease include the contents $(DEBUG_FILE) when submitting an issue or support request.\n"
@@ -152,7 +149,7 @@ debug:
 
 print-%  : ; @echo $* = $($*)
 
-HELP_VARS := PROJECT_NAME
+HELP_VARS := PROJECT_NAME DEBUG_FILE
 
 help-prefix:
 	@echo "To get started:"

--- a/{{ cookiecutter.repo_name }}/Makefile.envs
+++ b/{{ cookiecutter.repo_name }}/Makefile.envs
@@ -17,15 +17,11 @@ endif
 ## Set up virtual environment for this project
 create_environment: environment.$(ARCH).lock.yml
 ifeq (conda,$(VIRTUALENV))
-	touch environment.yml
+	@touch environment.yml
+	@echo
 	@echo "New conda env created. Activate with:"
 	@echo ">>> conda activate $(PROJECT_NAME)"
 	@echo ">>> make update_environment"
-	@echo
-	@echo "Now would be a good time to initialize a git repo; i.e."
-	@echo ">>> git init"
-	@echo ">>> git add ."
-	@echo ">>> git commit -m 'initial import'"
 ifneq ("X$(wildcard .post-create-environment.txt)","X")
 	@cat .post-create-environment.txt
 endif

--- a/{{ cookiecutter.repo_name }}/Makefile.envs
+++ b/{{ cookiecutter.repo_name }}/Makefile.envs
@@ -14,7 +14,7 @@ else
 endif
 
 .PHONY: create_environment
-## Set up virtual environment for this project
+## Set up virtual (conda) environment for this project
 create_environment: environment.$(ARCH).lock.yml
 ifeq (conda,$(VIRTUALENV))
 	@touch environment.yml
@@ -30,7 +30,7 @@ else
 endif
 
 .PHONY: delete_environment
-## Delete the virtual environment for this project
+## Delete the virtual (conda) environment for this project
 delete_environment:
 ifeq (conda,$(VIRTUALENV))
 	@echo "Deleting conda environment."
@@ -44,14 +44,13 @@ else
 endif
 
 .PHONY: update_environment
-## Install or update Python Dependencies
+## Install or update Python Dependencies in the virtual (conda) environment
 update_environment: test_environment environment.$(ARCH).lock.yml
 ifneq ("X$(wildcard .post-update-environment.txt)","X")
 	@cat .post-update-environment.txt
 endif
 
 .PHONY: test_environment
-## Test python environment is set-up correctly
 test_environment:
 ifeq (conda,$(VIRTUALENV))
 ifneq ($(notdir ${CONDA_DEFAULT_ENV}), $(PROJECT_NAME))

--- a/{{ cookiecutter.repo_name }}/Makefile.envs
+++ b/{{ cookiecutter.repo_name }}/Makefile.envs
@@ -17,9 +17,10 @@ endif
 ## Set up virtual environment for this project
 create_environment: environment.$(ARCH).lock.yml
 ifeq (conda,$(VIRTUALENV))
-	$(CONDA_EXE) env update -n $(PROJECT_NAME) -f environment.$(ARCH).lock.yml
+	touch environment.yml
 	@echo "New conda env created. Activate with:"
 	@echo ">>> conda activate $(PROJECT_NAME)"
+	@echo ">>> make update_environment"
 	@echo
 	@echo "Now would be a good time to initialize a git repo; i.e."
 	@echo ">>> git init"

--- a/{{ cookiecutter.repo_name }}/Makefile.envs
+++ b/{{ cookiecutter.repo_name }}/Makefile.envs
@@ -56,7 +56,7 @@ endif
 ## Test python environment is set-up correctly
 test_environment:
 ifeq (conda,$(VIRTUALENV))
-ifneq (${CONDA_DEFAULT_ENV}, $(PROJECT_NAME))
+ifneq (($(notdir ${CONDA_DEFAULT_ENV}), $(PROJECT_NAME))
 	$(error Must activate `$(PROJECT_NAME)` environment before proceeding)
 endif
 else

--- a/{{ cookiecutter.repo_name }}/Makefile.envs
+++ b/{{ cookiecutter.repo_name }}/Makefile.envs
@@ -56,7 +56,7 @@ endif
 ## Test python environment is set-up correctly
 test_environment:
 ifeq (conda,$(VIRTUALENV))
-ifneq (($(notdir ${CONDA_DEFAULT_ENV}), $(PROJECT_NAME))
+ifneq ($(notdir ${CONDA_DEFAULT_ENV}), $(PROJECT_NAME))
 	$(error Must activate `$(PROJECT_NAME)` environment before proceeding)
 endif
 else

--- a/{{ cookiecutter.repo_name }}/Makefile.envs
+++ b/{{ cookiecutter.repo_name }}/Makefile.envs
@@ -38,6 +38,7 @@ delete_environment:
 ifeq (conda,$(VIRTUALENV))
 	@echo "Deleting conda environment."
 	$(CONDA_EXE) env remove -n $(PROJECT_NAME)
+	rm environment.$(ARCH).lock.yml
 ifneq ("X$(wildcard .post-delete-environment.txt)","X")
 	@cat .post-delete-environment.txt
 endif

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -20,18 +20,16 @@ REQUIREMENTS
 
 GETTING STARTED
 ---------------
-### Checking out the repo
-Note: These instructions assume you are using SSH keys (and not HTTPS authentication) with gitlab.
-If you haven't set up SSH access to GitLab, see [Configuring SSH Access to Github or GitLab](https://github.com/hackalog/cookiecutter-easydata/wiki/Configuring-SSH-Access-to-Github). This also includes instuctions for using more than one account with SSH keys.
+### Git Configuraiton and Checking Out the Repo
 
-1. Fork the repo (on GitLab) to your personal account
-1. Clone your fork to your local machine
-  `git clone git@gitlab.com:<your gitlab handle>/{{cookiecutter.repo_name}}.git`
-1. Add the main source repo as a remote branch called `upstream` (to make syncing easier):
-  `cd {{cookiecutter.repo_name}}`
-  `git remote add upstream git@gitlab.com:<upstream-repo>/{{cookiecutter.repo_name}}.git`
+If you haven't yet done so, please follow the instrucitons
+in [Setting up git and Checking Out the Repo](framework-docs/git-configuration.md) in
+order to check-out the code and set-up your remote branches
 
-You're all set for staying up-to-date with the project repo. Follow the instructions in this handy [Gitlab Workflow Cheat Sheet](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) for keeping your working copy of the repo in sync.
+Note: These instructions assume you are using SSH keys (and not HTTPS authentication) with {{ cookiecutter.upstream_location }}.
+If you haven't set up SSH access to {{ cookiecutter.upstream_location }}, see [Configuring SSH Access to {{cookiecutter.upstream_location}}](https://github.com/hackalog/cookiecutter-easydata/wiki/Configuring-SSH-Access-to-Github). This also includes instuctions for using more than one account with SSH keys.
+
+Once you've got your local, `origin`, and `upstream` branches configured, you can follow the instructions in this handy [Git Workflow Cheat Sheet](framework-docs/git-workflow.md) to keep your working copy of the repo in sync with the others.
 
 ### Setting up your environment
 **WARNING**: If you have conda-forge listed as a channel in your `.condarc` (or any other channels other than defaults), remove it during the course of the workshop. Even better, don't use a `.condarc` for managing channels, as it overrides the `environment.yml` instructions and makes things less reproducible. Make the changes to the `environment.yml` file if necessary. We've had some conda-forge related issues with version conflicts. We also recommend [setting your channel priority to 'strict'](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html) to reduce package incompatibility problems.

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -1,6 +1,6 @@
 {{cookiecutter.project_name}}
 ==============================
-_Author: {{ cookiecutter.author_name }}
+_Author: {{ cookiecutter.author_name }}_
 
 {{cookiecutter.description}}
 
@@ -21,17 +21,17 @@ REQUIREMENTS
 GETTING STARTED
 ---------------
 ### Checking out the repo
-Note: These instructions assume you are using SSH keys (and not HTTPS authentication) with github.
-If you haven't set up SSH access to GitHub, see [Configuring SSH Access to Github](https://github.com/hackalog/cookiecutter-easydata/wiki/Configuring-SSH-Access-to-Github). This also includes instuctions for using more than one account with SSH keys.
+Note: These instructions assume you are using SSH keys (and not HTTPS authentication) with gitlab.
+If you haven't set up SSH access to GitLab, see [Configuring SSH Access to Github or GitLab](https://github.com/hackalog/cookiecutter-easydata/wiki/Configuring-SSH-Access-to-Github). This also includes instuctions for using more than one account with SSH keys.
 
-1. Fork the repo (on GitHub) to your personal account
+1. Fork the repo (on GitLab) to your personal account
 1. Clone your fork to your local machine
-  `git clone git@github.com:<your github handle>/{{cookiecutter.project_name}}.git`
+  `git clone git@gitlab.com:<your gitlab handle>/{{cookiecutter.project_name}}.git`
 1. Add the main source repo as a remote branch called `upstream` (to make syncing easier):
   `cd {{cookiecutter.project_name}}`
-  `git remote add upstream git@github.com:<upstream-repo>/{{cookiecutter.project_name}}.git`
+  `git remote add upstream git@gitlab.com:<upstream-repo>/{{cookiecutter.project_name}}.git`
 
-You're all set for staying up-to-date with the project repo. Follow the instructions in this handy [Github Workflow Cheat Sheet](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) for keeping your working copy of the repo in sync.
+You're all set for staying up-to-date with the project repo. Follow the instructions in this handy [Gitlab Workflow Cheat Sheet](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) for keeping your working copy of the repo in sync.
 
 ### Setting up your environment
 **WARNING**: If you have conda-forge listed as a channel in your `.condarc` (or any other channels other than defaults), remove it during the course of the workshop. Even better, don't use a `.condarc` for managing channels, as it overrides the `environment.yml` instructions and makes things less reproducible. Make the changes to the `environment.yml` file if necessary. We've had some conda-forge related issues with version conflicts. We also recommend [setting your channel priority to 'strict'](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html) to reduce package incompatibility problems.

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -26,10 +26,10 @@ If you haven't set up SSH access to GitLab, see [Configuring SSH Access to Githu
 
 1. Fork the repo (on GitLab) to your personal account
 1. Clone your fork to your local machine
-  `git clone git@gitlab.com:<your gitlab handle>/{{cookiecutter.project_name}}.git`
+  `git clone git@gitlab.com:<your gitlab handle>/{{cookiecutter.repo_name}}.git`
 1. Add the main source repo as a remote branch called `upstream` (to make syncing easier):
-  `cd {{cookiecutter.project_name}}`
-  `git remote add upstream git@gitlab.com:<upstream-repo>/{{cookiecutter.project_name}}.git`
+  `cd {{cookiecutter.repo_name}}`
+  `git remote add upstream git@gitlab.com:<upstream-repo>/{{cookiecutter.repo_name}}.git`
 
 You're all set for staying up-to-date with the project repo. Follow the instructions in this handy [Gitlab Workflow Cheat Sheet](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) for keeping your working copy of the repo in sync.
 

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -20,7 +20,7 @@ REQUIREMENTS
 
 GETTING STARTED
 ---------------
-### Git Configuraiton and Checking Out the Repo
+### Git Configuration and Checking Out the Repo
 
 If you haven't yet done so, please follow the instrucitons
 in [Setting up git and Checking Out the Repo](framework-docs/git-configuration.md) in

--- a/{{ cookiecutter.repo_name }}/environment.yml
+++ b/{{ cookiecutter.repo_name }}/environment.yml
@@ -34,4 +34,5 @@ dependencies:
   - pandas
   - requests
   - pathlib
+  - fsspec
 {{ pyver()|indent(2, true) }}

--- a/{{ cookiecutter.repo_name }}/framework-docs/conda-environments.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/conda-environments.md
@@ -2,17 +2,13 @@
 
 The `{{ cookiecutter.repo_name }}` repo is set up with template code to make managing your conda environments easy and reproducible. Not only will _future you_ appreciate this, but so will anyone else who needs to work with your code after today.
 
-If you haven't yet, set up your conda environment
+If you haven't yet, configure your conda environment.
+
+## Configuring your python environment
+Easydata uses conda to manage python packages installed by both conda **and pip**.
 
 ### Adjust your `.condarc`
 **WARNING FOR EXISTING CONDA USERS**: If you have `conda-forge` listed as a channel in your `.condarc` (or any other channels other than `default`), **remove them**. These channels should be specified in `environment.yml` instead.
-
-**Note for Jupyterhub Users**: You will need to store your conda environment in your **home directory** so that they wil be persisted across JupyterHub sessions.
-```
-conda init
-bash
-conda config --prepend envs_dirs ~/.conda/envs   # Store environments in local dir for JupyterHub
-```
 
 We also recommend [setting your channel priority to 'strict'](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html) to reduce package incompatibility problems. This will be the default in conda 5.0, but in order to assure reproducibility, we need to use this behavior now.
 
@@ -23,6 +19,11 @@ Whenever possible, re-order your channels so that `default` is first.
 
 ```
 conda config --prepend channels defaults
+```
+
+**Note for Jupyterhub Users**: You will need to store your conda environment in your **home directory** so that they wil be persisted across JupyterHub sessions.
+```
+conda config --prepend envs_dirs ~/.conda/envs   # Store environments in local dir for JupyterHub
 ```
 
 ### Fix the CONDA_EXE path
@@ -49,14 +50,15 @@ To activate the environment, simply `conda activate {{ cookiecutter.repo_name }}
 
 To deactivate it and return to your base environment, use `conda deactivate`
 
-### Further Instructions
+## Maintaining your Python environment
 
-#### Updating your conda and pip environments
-The `make` commands, `make create_environment` and `make update_environment` are wrappers that allow you to easily manage your conda and pip environments using the `environment.yml` file. If you want to make changes to your environment, do so by editing the `environment.yml` file and then running `make update_environment`.
+### Updating your conda and pip environments
+The `make` commands, `make create_environment` and `make update_environment` are wrappers that allow you to easily manage your conda and pip environments using the `environment.yml` file.
 
-When adding packages to your python environment, **do not `pip install` or `conda install` directly**. Always edit `environment.yml` and `make update_environment`.
+(If you ever forget which `make` command to run, you can run `make` by itself and it will provide a list of commands that are available.)
 
-If you ever forget which `make` command to run, you can run `make` and it will provide a list of commands that are available.
+
+When adding packages to your python environment, **do not `pip install` or `conda install` directly**. Always edit `environment.yml` and `make update_environment` instead.
 
 Your `environment.yml` file will look something like this:
 ```

--- a/{{ cookiecutter.repo_name }}/framework-docs/conda-environments.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/conda-environments.md
@@ -1,23 +1,41 @@
 # Setting up and Maintaining your Conda Environment (Reproducibly)
 
-The `{{ cookiecutter.repo_name }}` repo is set up with template code to make managing your conda environments easy and reproducible. Not only will future you appreciate this, but everyone else who tries to run your code will thank you.
+The `{{ cookiecutter.repo_name }}` repo is set up with template code to make managing your conda environments easy and reproducible. Not only will _future you_ appreciate this, but so will anyone else who needs to work with your code after today.
 
-If you haven't yet, get your initial environment set up.
+If you haven't yet, set up your conda environment
 
-### Quickstart Instructions
-**WARNING FOR EXISTING CONDA USERS**: If you have conda-forge listed as a channel in your `.condarc` (or any other channels other than defaults), remove it during the course of the project. Even better, don't use a `.condarc` for managing channels, as it overrides the `environment.yml` instructions and makes things less reproducible. Make the changes to the `environment.yml` file if necessary. We've had some conda-forge related issues with version conflicts.
+### Adjust your `.condarc`
+**WARNING FOR EXISTING CONDA USERS**: If you have `conda-forge` listed as a channel in your `.condarc` (or any other channels other than `default`), **remove them**. These channels should be specified in `environment.yml` instead.
 
-We also recommend [setting your channel priority to 'strict'](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html) to reduce package incompatibility problems. This will be default in future conda releases, but it is being rolled out gently.
+**Note for Jupyterhub Users**: You will need to store your conda environment in your **home directory** so that they wil be persisted across JupyterHub sessions.
+```
+conda init
+bash
+conda config --prepend envs_dirs ~/.conda/envs   # Store environments in local dir for JupyterHub
+```
 
+We also recommend [setting your channel priority to 'strict'](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html) to reduce package incompatibility problems. This will be the default in conda 5.0, but in order to assure reproducibility, we need to use this behavior now.
+
+```
+conda config --set channel_priority strict
+```
+Whenever possible, re-order your channels so that `default` is first.
+
+```
+conda config --prepend channels defaults
+```
+
+### Fix the CONDA_EXE path
 * Make note of the path to your conda binary:
 ```
    $ which conda
    ~/miniconda3/bin/conda
 ```
-* ensure your `CONDA_EXE` environment variable is set to this value (or edit `Makefile.include` directly)
+* ensure your `CONDA_EXE` environment variable is set correctly in `Makefile.include`
 ```
     export CONDA_EXE=~/miniconda3/bin/conda
 ```
+### Create the conda environment
 * Create and switch to the virtual environment:
 ```
 cd {{ cookiecutter.repo_name }}
@@ -25,16 +43,20 @@ make create_environment
 conda activate {{ cookiecutter.repo_name }}
 make update_environment
 ```
-Note: you need to run `make update_environment` for the `{{ cookiecutter.module_name }}` module to install correctly.
+**Note**: When creating the environment the first time, you really do need to run **both** `make create_environment` and `make update_environment` for the `{{ cookiecutter.module_name }}` module to install correctly.
 
-From here on, to use the environment, simply `conda activate {{ cookiecutter.repo_name }}` and `conda deactivate` to go back to the base environment.
+To activate the environment, simply `conda activate {{ cookiecutter.repo_name }}`
+
+To deactivate it and return to your base environment, use `conda deactivate`
 
 ### Further Instructions
 
-#### Updating your environment
-The `make` commands, `make create_environment` and `make update_environment` are wrappers that allow you to easily manage your environment using the `environment.yml` file. If you want to make changes to your environment, do so by editing the `environment.yml` file and then running `make update_environment`.
+#### Updating your conda and pip environments
+The `make` commands, `make create_environment` and `make update_environment` are wrappers that allow you to easily manage your conda and pip environments using the `environment.yml` file. If you want to make changes to your environment, do so by editing the `environment.yml` file and then running `make update_environment`.
 
-If you ever forget which make command to run, you can run `make` and it will list a magic menu of which make commands are available.
+When adding packages to your python environment, **do not `pip install` or `conda install` directly**. Always edit `environment.yml` and `make update_environment`.
+
+If you ever forget which `make` command to run, you can run `make` and it will provide a list of commands that are available.
 
 Your `environment.yml` file will look something like this:
 ```
@@ -64,12 +86,12 @@ name: {{ cookiecutter.repo_name }}
 ```
 To add any package available from conda, add it to the end of the list. If you have a PYPI dependency that's not avaible via conda, add it to the list of pip installable dependencies under `  - pip:`.
 
-You can include any GitHub python-based project in the `pip` section via `git+https://github.com/<github handle>/<package>`.
+You can include any {{ cookiecutter.upstream_location }} python-based project in the `pip` section via `git+https://{{ cookiecutter.upstream_location }}/<my_git_handle>/<package>`.
 
-In particular, if you're working off of a fork or a work in progress branch of a repo in GitHub (say, your personal version of <package>), you can change `git+https://github.com/<github handle>/<package>` to
+In particular, if you're working off of a fork or a work in progress branch of a repo in {{ cookiecutter.upstream_location }} (say, your personal version of <package>), you can change `git+https://{{ cookiecutter.upstream_location }}/<my_git_handle>/<package>` to
 
-* `git+https://github.com/<my github handle>/<package>.git` to point to the master branch of your fork and
-* `git+https://github.com/<my github handle>/<package>.git@<my branch>` to point to a specific branch.
+* `git+https://{{ cookiecutter.upstream_location }}/<my_git_handle>/<package>.git` to point to the {{cookiecutter.default_branch}} branch of your fork and
+* `git+https://{{ cookiecutter.upstream_location }}/<my_git_handle>/<package>.git@<my branch>` to point to a specific branch.
 
 Once you're done your edits, run `make update_environment` and voila, you're updated.
 

--- a/{{ cookiecutter.repo_name }}/framework-docs/git-configuration.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/git-configuration.md
@@ -23,7 +23,7 @@ git calls `upstream` (the **team repo**), and `origin` (your **personal fork** o
 
 Create a local git checkout by cloning your personal fork:
 ```bash
-git clone git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git
+git clone git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.repo_name}}.git
 ```
 Add the team (shared) repo as a remote branch named `upstream`:
 ```bash
@@ -35,10 +35,17 @@ You can verify that these branches are configured correctly by typing
 
 ```
 >>> git remote -v
-origin	git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git (fetch)
-origin	git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git (push)
+origin	git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.repo_name}}.git (fetch)
+origin	git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.repo_name}}.git (push)
 upstream	git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git (fetch)
 upstream	git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git (push)
+```
+or if you use HTTPS-based authentication:
+```
+origin	https://{{ cookiecutter.upstream_location }}/<your_git_handle>/{{cookiecutter.repo_name}}.git (fetch)
+origin	https://{{ cookiecutter.upstream_location }}/<your_git_handle>/{{cookiecutter.repo_name}}.git (push)
+upstream	https://{{ cookiecutter.upstream_location }}/<upstream-repo>/{{cookiecutter.repo_name}}.git (fetch)
+upstream	https://{{ cookiecutter.upstream_location }}/<upstream-repo>/{{cookiecutter.repo_name}}.git (push)
 ```
 
 ### Do Your Work in Branches

--- a/{{ cookiecutter.repo_name }}/framework-docs/git-configuration.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/git-configuration.md
@@ -1,0 +1,48 @@
+# Setting up git and Checking Out the Repo
+
+**Note**: These instructions assume you are using SSH keys (and not HTTPS authentication) with {{ cookiecutter.upstream_location }}. If you haven't set up SSH access to your repo host, see [Configuring SSH Access to Github or Gitlab][git-ssh]. This also includes instructions for using more than one account with SSH keys.
+
+[git-ssh]: https://github.com/hackalog/cookiecutter-easydata/wiki/Configuring-SSH-Access-to-Github-or-GitLab
+
+## Git Configuration
+When sharing a git repo with a small team, your code usually lives in at least 3 different places:
+
+* "local" refers to any git checkout on a local machine (or JupyterHub instance). This is where you work most of the time.
+* `upstream` refers to the shared Easydata repo on {{ cookiecutter.upstream_location}}; i.e. the **team repo**,
+* `origin` refers to your **personal fork** of the shared Easydata repo. It also lives on {{ cookiecutter.upstream_location}}.
+
+### Create a Personal Fork
+
+We strongly recommend you make all your edits on a personal fork of this repo. Here's how to create such a fork:
+
+* On Github or Gitlab, press the Fork button in the top right corner.
+* On Bitbucket, press the "+" icon on the left and choose **Fork this Repo**
+
+### Local, `origin`, and `upstream`
+git calls `upstream` (the **team repo**), and `origin` (your **personal fork** of the team repo) "remote" branches. Here's how to create them.
+
+Create a local git checkout by cloning your personal fork:
+```bash
+git clone git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git
+```
+Add the team (shared) repo as a remote branch named `upstream`:
+```bash
+  cd {{cookiecutter.repo_name}}
+  git remote add upstream git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git
+```
+
+You can verify that these branches are configured correctly by typing
+
+```
+>>> git remote -v
+origin	git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git (fetch)
+origin	git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git (push)
+upstream	git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git (fetch)
+upstream	git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git (push)
+```
+
+### Do Your Work in Branches
+To make life easiest, we recommend you do all your development **in branches**, and use your {{cookiecutter.default_branch}} branch **only** for tracking changes in the shared `upstream/{{cookiecutter.default_branch}}`. This combination makes it much easier not only to stay up to date with changes in the shared project repo, but also makes it easier to submit Pull/Merge Requests (PRs) against the upstream project repository should you want to share your code or data.
+
+### A Useful Git Workflow
+Once you've got your local, `origin`, and `upstream` branches configured, you can follow the instructions in this handy [Git Workflow Cheat Sheet](git-workflow.md) to keep your working copy of the repo in sync with the others.

--- a/{{ cookiecutter.repo_name }}/framework-docs/git-workflow.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/git-workflow.md
@@ -4,7 +4,7 @@ Here's our suggestion for a reliable git workflow that works well in small team 
 ## Git configuration
 
 If you haven't yet done so, please follow the instrucitons
-in [Setting up git and Checking Out the Repo](git-configuration.md) first.
+in our [Git Configuration Guide](git-configuration.md) first.
 
 ## Git Workflow
 
@@ -40,7 +40,7 @@ git push origin {{cookiecutter.default_branch}}
 make update_environment
 ```
 
-### Update your local branches
+### Am I working from the latest `{{cookiecutter.default_branch}}`?
 Now that your `{{cookiecutter.default_branch}}` branch is up-to-date with both `origin` and `upstream`, you should use it to update your local working branches. If you are already developing in a branch called, e.g. `my_branch`, do this before writing any more code:
 
 ```bash
@@ -49,21 +49,24 @@ git merge {{cookiecutter.default_branch}}
 git push origin my_branch
 ```
 
-### Start a new branch for the day's work
-Create a clean working branch by doing a:
+### Do I have any stale branches?
+With your local `{{cookiecutter.default_branch}}`, `origin/{{cookiecutter.default_branch}}` and `upstream/{{cookiecutter.default_branch}}` all in sync, we like to clean up any old branches that are fully merged (and hence, can be deleted without data loss.)
+```bash
+git branch --merged {{cookiecutter.default_branch}}
+git branch -d <name_of_merged_branch>
+```
+A really great feature of `git branch -d` is that it will refuse to remove a branch that hasn't been fully merged into another. Thus it's safe to use without any fear of data loss.
+
+
+### Time to start the day
+Once you've finished all your merge tasks, you can create a clean working branch from the latest `{{cookiecutter.default_branch}}` by doing a:
 ```bash
 git checkout {{cookiecutter.default_branch}}
 git checkout -b new_branch_name
 ```
 
-### Clean up the old branches
-Now that you're up-to-date, you can clean up any of your old branches that are fully merged (and hence, can be deleted.)
-```bash
-git branch --merged {{cookiecutter.default_branch}}
-git branch -d <name_of_merged_branch>
-```
 
-Got any suggestions for improvements to this workflow? File an issue at
+That's it!. Do you have any suggestions for improvements to this workflow? Drop us a line or file an issue at
 [cookiecutter-easydata].
 
 [cookiecutter-easydata]: https://github.com/hackalog/cookiecutter-easydata/

--- a/{{ cookiecutter.repo_name }}/framework-docs/git-workflow.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/git-workflow.md
@@ -1,51 +1,12 @@
 # The Easydata Git Workflow
 Here's our suggestion for a reliable git workflow that works well in small team settings using [Easydata][cookiecutter-easydata].
 
-**Note**: These instructions assume you are using SSH keys (and not HTTPS authentication) with {{ cookiecutter.upstream_location }}. If you haven't set up SSH access to your repo host, see [Configuring SSH Access to Github or Gitlab][git-ssh]. This also includes instructions for using more than one account with SSH keys.
+## Git configuration
 
-[git-ssh]: https://github.com/hackalog/cookiecutter-easydata/wiki/Configuring-SSH-Access-to-Github-or-GitLab
+If you haven't yet done so, please follow the instrucitons
+in [Setting up git and Checking Out the Repo](git-configuration.md) first.
 
-## Git Configuration
-When sharing a git repo with a small team, your code usually lives in at least 3 different places:
-
-* "local" refers to any git checkout on a local machine (or JupyterHub instance). This is where you work most of the time.
-* `upstream` refers to the shared Easydata repo on {{ cookiecutter.upstream_location}}; i.e. the **team repo**,
-* `origin` refers to your **personal fork** of the shared Easydata repo. It also lives on {{ cookiecutter.upstream_location}}.
-
-### Create a Personal Fork
-
-We strongly recommend you make all your edits on a personal fork of this repo. Here's how to create such a fork:
-
-* On Github or Gitlab, press the Fork button in the top right corner.
-* On Bitbucket, press the "+" icon on the left and choose **Fork this Repo**
-
-### Local, `origin`, and `upstream`
-git calls `upstream` (the **team repo**), and `origin` (your **personal fork** of the team repo) "remote" branches. Here's how to create them.
-
-Create a local git checkout by cloning your personal fork:
-```bash
-git clone git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git
-```
-Add the team (shared) repo as a remote branch named `upstream`:
-```bash
-  cd {{cookiecutter.repo_name}}
-  git remote add upstream git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git
-```
-
-You can verify that these branches are configured correctly by typing
-
-```
->>> git remote -v
-origin	git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git (fetch)
-origin	git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git (push)
-upstream	git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git (fetch)
-upstream	git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git (push)
-```
-
-### Work in Branches
-To make life easiest, we recommend you do all your development **in branches**, and use your {{cookiecutter.default_branch}} branch **only** for tracking changes in the shared `upstream/{{cookiecutter.default_branch}}`. This combination makes it much easier not only to stay up to date with changes in the shared project repo, but also makes it easier to submit Pull/Merge Requests (PRs) against the upstream project repository should you want to share your code or data.
-
-## The Easydata git workflow
+## Git Workflow
 
 We suggest you start each day by doing this:
 

--- a/{{ cookiecutter.repo_name }}/framework-docs/git-workflow.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/git-workflow.md
@@ -1,0 +1,108 @@
+# The Easydata Git Workflow
+Here's our suggestion for a reliable git workflow that works well in small team settings using [Easydata][cookiecutter-easydata].
+
+**Note**: These instructions assume you are using SSH keys (and not HTTPS authentication) with {{ cookiecutter.upstream_location }}. If you haven't set up SSH access to your repo host, see [Configuring SSH Access to Github or Gitlab][git-ssh]. This also includes instructions for using more than one account with SSH keys.
+
+[git-ssh]: https://github.com/hackalog/cookiecutter-easydata/wiki/Configuring-SSH-Access-to-Github-or-GitLab
+
+## Git Configuration
+When sharing a git repo with a small team, your code usually lives in at least 3 different places:
+
+* "local" refers to any git checkout on a local machine (or JupyterHub instance). This is where you work most of the time.
+* `upstream` refers to the shared Easydata repo on {{ cookiecutter.upstream_location}}; i.e. the **team repo**,
+* `origin` refers to your **personal fork** of the shared Easydata repo. It also lives on {{ cookiecutter.upstream_location}}.
+
+### Create a Personal Fork
+
+We strongly recommend you make all your edits on a personal fork of this repo. Here's how to create such a fork:
+
+* On Github or Gitlab, press the Fork button in the top right corner.
+* On Bitbucket, press the "+" icon on the left and choose **Fork this Repo**
+
+### Local, `origin`, and `upstream`
+git calls `upstream` (the **team repo**), and `origin` (your **personal fork** of the team repo) "remote" branches. Here's how to create them.
+
+Create a local git checkout by cloning your personal fork:
+```bash
+git clone git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git
+```
+Add the team (shared) repo as a remote branch named `upstream`:
+```bash
+  cd {{cookiecutter.repo_name}}
+  git remote add upstream git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git
+```
+
+You can verify that these branches are configured correctly by typing
+
+```
+>>> git remote -v
+origin	git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git (fetch)
+origin	git@{{ cookiecutter.upstream_location }}:<your_git_handle>/{{cookiecutter.project_name}}.git (push)
+upstream	git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git (fetch)
+upstream	git@{{ cookiecutter.upstream_location }}:<upstream-repo>/{{cookiecutter.repo_name}}.git (push)
+```
+
+### Work in Branches
+To make life easiest, we recommend you do all your development **in branches**, and use your {{cookiecutter.default_branch}} branch **only** for tracking changes in the shared `upstream/{{cookiecutter.default_branch}}`. This combination makes it much easier not only to stay up to date with changes in the shared project repo, but also makes it easier to submit Pull/Merge Requests (PRs) against the upstream project repository should you want to share your code or data.
+
+## The Easydata git workflow
+
+We suggest you start each day by doing this:
+
+### Where was I? What was I doing? Did I check it in?
+Sometimes, you stop work without checking things back in to the repo.
+Now, before you do any additional work, is the time to fix that.
+```bash
+git branch   # what branch am I on?
+git status   # are there any files that need checking in?
+git add -p   # accept or reject parts of the modified files
+git commit -m "put your commit message here"
+```
+
+### Did I do any work elsewhere?
+Did you make changes to your personal fork, but on a different machine? Make sure your local branch is up-to-date with your personal fork (`origin`):
+```bash
+git checkout {{cookiecutter.default_branch}}
+git fetch origin --prune
+git merge origin/{{cookiecutter.default_branch}}
+```
+
+### What happened upstream?
+Did someone make changes to the `upstream` repo in your absense?
+Let's fetch and merge those changes
+
+```bash
+git checkout {{cookiecutter.default_branch}}
+git fetch upstream --prune
+git merge upstream/{{cookiecutter.default_branch}}
+git push origin {{cookiecutter.default_branch}}
+make update_environment
+```
+
+### Update your local branches
+Now that your `{{cookiecutter.default_branch}}` branch is up-to-date with both `origin` and `upstream`, you should use it to update your local working branches. If you are already developing in a branch called, e.g. `my_branch`, do this before writing any more code:
+
+```bash
+git checkout my_branch
+git merge {{cookiecutter.default_branch}}
+git push origin my_branch
+```
+
+### Start a new branch for the day's work
+Create a clean working branch by doing a:
+```bash
+git checkout {{cookiecutter.default_branch}}
+git checkout -b new_branch_name
+```
+
+### Clean up the old branches
+Now that you're up-to-date, you can clean up any of your old branches that are fully merged (and hence, can be deleted.)
+```bash
+git branch --merged {{cookiecutter.default_branch}}
+git branch -d <name_of_merged_branch>
+```
+
+Got any suggestions for improvements to this workflow? File an issue at
+[cookiecutter-easydata].
+
+[cookiecutter-easydata]: https://github.com/hackalog/cookiecutter-easydata/

--- a/{{ cookiecutter.repo_name }}/framework-docs/sharing-your-work.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/sharing-your-work.md
@@ -2,7 +2,7 @@
 
 * [Contributor Guidelines and Checklist](#contributor-guide-and-checklist)
 * [Best Practices for Sharing](#best-practices-for-sharing)
-  * [Sharing Code Using Git and GitHub](#sharing-code-using-git-and-github)
+  * [Sharing Code Using Git and GitLab](#sharing-code-using-git-and-github)
   * [Sharing Datasets](#sharing-datasets)
   * [Sharing Conda Environments](#sharing-conda-environments)
   * [Sharing Notebooks](#sharing-notebooks)
@@ -42,11 +42,11 @@ When you are ready share your notebook or code with others, you'll be able to ti
 - [ ] Share your conda environment. Check in your `environment.yml` file if you've made any changes.
   * If there's any chance that you added something to the conda environment needed to run your code that was **not** added via your `environment.yml` file as per [Setting up and Maintaining your Conda Environment (Reproducibly)](conda-environments.md), [delete your environment and recreate it](conda-environments.md#nuke-it-from-orbit).
 - [ ] *(Optional)* Make sure all tests pass (run `make test`). This will test all of the dataset integration so if you don't have a lot of room on your machine (as it will build all the the datasets if you haven't yet), you may want to skip this step.
-- [ ] At least, make sure all of the tests for your code pass. To subselect your tests you can run `pytest --pyargs {{ cookiecutter.module_name }} -k your_test_filename`.
+- [ ] At least, make sure all of the tests for your code pass. To subselect your tests you can run `pytest --pyargs src -k your_test_filename`.
 
 #### Final Checks
 - [ ] You've [merged the latest version](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) of `upstream/master` into your branch.
-- [ ] [Submitted a PR via GitHub](#how-to-submit-a-PR) in **Draft** status and checked the PR diff to make sure that you aren't missing anything critical, you're not adding anything extraneous, and you don't have any merge conflicts.
+- [ ] [Submitted a PR via GitLab](#how-to-submit-a-PR) in **Draft** status and checked the PR diff to make sure that you aren't missing anything critical, you're not adding anything extraneous, and you don't have any merge conflicts.
 
 Once this checklist is complete, take your **PR** out of **Draft** status. It's ready to go!
 
@@ -54,15 +54,15 @@ As a person who is trying to contribute and share your work with others, it may 
 
 
 ## Best Practices for Sharing
-### Sharing Code Using Git and GitHub
+### Sharing Code Using Git and GitLab
 
 Quick References:
 
-* Keeping up-to-date: [Our GitHub Workflow](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet)
+* Keeping up-to-date: [Our GitLab Workflow](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet)
 * Recommended [Git tutorial](https://github.com/hackalog/cookiecutter-easydata/wiki/Git-Tutorial)
 
 
-There are several ways to use Git and GitHub successfully, and a lot more ways to use them unsuccessfully when working with lots of other people. Here are some best practices that we suggest you use to make your life, and our lives easier. This workflow we suggest makes choosing which changes to put in a pull request easier, and helps to avoid crazy merge conflicts.
+There are several ways to use Git and GitLab successfully, and a lot more ways to use them unsuccessfully when working with lots of other people. Here are some best practices that we suggest you use to make your life, and our lives easier. This workflow we suggest makes choosing which changes to put in a pull request easier, and helps to avoid crazy merge conflicts.
 
 First off, follow the [Getting Started](../README.md#getting-started) instructions for setting yourself up to work off of your own fork. The idea here will be to keep `upstream/master`, your local `master` and your `origin/master` all in sync with each other.
 
@@ -71,17 +71,17 @@ Any changes should be made in a separate branch---**not** your `master`---that y
 1. Make sure your `master` is up-to-date with upstream `git fetch upstream` and `git merge upstream/master`
 1. Make sure your environment is up-to-date with upstream `make update_environment`
 1. Start your work (from your up-to-date `master`) in a new branch: `git checkout -b my_new_branch`
-1. Commit all your changes to `my_new_branch` (as per the [Github Workflow](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet))
+1. Commit all your changes to `my_new_branch` (as per the [GitLab Workflow](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet))
 
 
-You can pretty much blindly do this by following the [Github Workflow](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) religiously.
+You can pretty much blindly do this by following the [GitLab Workflow](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) religiously.
 
 #### How to submit a PR
 
-1. Push to your GitHub fork by `git push origin my_new_branch`.
-1. If this is the first time you do this from `my_new_branch`, you'll be prompted with a URL from your terminal for how to create a PR. Otherwise, if you go to GitHub, you'll see a yellow banner at the top of the screen prompting you to submit a PR (as long as you're not out of sync with the `upstream master`, in which case, re-sync your branch).
+1. Push to your GitLab fork by `git push origin my_new_branch`.
+1. If this is the first time you do this from `my_new_branch`, you'll be prompted with a URL from your terminal for how to create a PR. Otherwise, if you go to GitLab, you'll see a yellow banner at the top of the screen prompting you to submit a PR (as long as you're not out of sync with the `upstream master`, in which case, re-sync your branch).
 1. You have the option to submit a PR in **Draft** status. Select this if you have a work in progress. It disables the ability to merge your PR.
-1. Once you submit your PR, there may be a yellow dot or red X beside your PR. This is because we have tests set up in CircleCI. If you are working in a private repo, you need to authorize access to CircleCI on your fork for tests to run successfully. To do so, follow the link to CircleCI and **authorize github** on your fork of the repo.
+1. Once you submit your PR, there may be a yellow dot or red X beside your PR. This is because we have tests set up in CircleCI. If you are working in a private repo, you need to authorize access to CircleCI on your fork for tests to run successfully. To do so, follow the link to CircleCI and **authorize gitlab** on your fork of the repo.
 1. When ready, take your PR out of **Draft** status.
 
 

--- a/{{ cookiecutter.repo_name }}/framework-docs/sharing-your-work.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/sharing-your-work.md
@@ -1,8 +1,8 @@
-# Sharing your Work
+ # Sharing your Work
 
 * [Contributor Guidelines and Checklist](#contributor-guide-and-checklist)
 * [Best Practices for Sharing](#best-practices-for-sharing)
-  * [Sharing Code Using Git and GitLab](#sharing-code-using-git-and-github)
+  * [Sharing Code Using Git and {{ cookiecutter.upstream_location }}](#sharing-code-using-git-and-github)
   * [Sharing Datasets](#sharing-datasets)
   * [Sharing Conda Environments](#sharing-conda-environments)
   * [Sharing Notebooks](#sharing-notebooks)
@@ -15,8 +15,8 @@ The main impetus of following the **recommended workflow** for this project is t
 We **want** you to share your work. We understand that your work may still be a **work-in-progress** when you first start to share it. We encourage that. There are three main ways to contribute to this repo:
 
 
-* **Filing and reporting issues:** Please don't be shy here. Chances are if you encounter an issue, someone else already has, or someone else will encounter the same issue in the future. Reporting helps us to find solutions that will work for everyone. Hacks and your personal work-arounds are not reproducible. No issue is too small. Share the love and let us solve issues as best we can for everyone. Issues include anything from "I had trouble understanding and following the documentation", to feature requests, to bugs in the main code repo.
-  1. First up, [make sure that you're working with the most up-to-date version](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) of the codebase.
+* **Filing and reporting issues:** Please don't be shy here. Chances are if you encounter an issue, someone else already has, or someone else will encounter the same issue in the future. Reporting helps us to find solutions that will work for everyone. Hacks and your personal work-arounds are not reproducible. No issue is too small. Share the love and let us solve issues as best we can for everyone. Issues include anything from "I had trouble understanding and following the documentation", to feature requests, to bugs in the shared codebase iteself.
+  1. First up, [make sure that you're working with the most up-to-date version](git-workflow.md) of the codebase.
   1. Check the [troubleshooting guide](conda-environments.md#troubleshooting) to see if a solution has already been documented.
   1. Check if the issue has been reported already. If so, make a comment on the issue to indicate that you're also having said issue.
   1. Finally, if your issue hasn't been resolved at this stage, file an issue. For bugs reports, please include reproducers.
@@ -45,8 +45,8 @@ When you are ready share your notebook or code with others, you'll be able to ti
 - [ ] At least, make sure all of the tests for your code pass. To subselect your tests you can run `pytest --pyargs {{ cookiecutter.module_name }} -k your_test_filename`.
 
 #### Final Checks
-- [ ] You've [merged the latest version](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) of `upstream/master` into your branch.
-- [ ] [Submitted a PR via GitLab](#how-to-submit-a-PR) in **Draft** status and checked the PR diff to make sure that you aren't missing anything critical, you're not adding anything extraneous, and you don't have any merge conflicts.
+- [ ] You've [merged the latest version](git-workflow.md) of `upstream/{{ cookiecutter.default_branch }}` into your branch.
+- [ ] [Submitted a PR via {{ cookiecutter.upstream_location }}](#how-to-submit-a-PR) in **Draft** status and checked the PR diff to make sure that you aren't missing anything critical, you're not adding anything extraneous, and you don't have any merge conflicts.
 
 Once this checklist is complete, take your **PR** out of **Draft** status. It's ready to go!
 
@@ -54,39 +54,39 @@ As a person who is trying to contribute and share your work with others, it may 
 
 
 ## Best Practices for Sharing
-### Sharing Code Using Git and GitLab
+### Sharing Code Using Git and {{ cookiecutter.upstream_location }}
 
 Quick References:
 
-* Keeping up-to-date: [Our GitLab Workflow](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet)
+* Keeping up-to-date: [Our Git Workflow](git-workflow.md)
 * Recommended [Git tutorial](https://github.com/hackalog/cookiecutter-easydata/wiki/Git-Tutorial)
 
 
-There are several ways to use Git and GitLab successfully, and a lot more ways to use them unsuccessfully when working with lots of other people. Here are some best practices that we suggest you use to make your life, and our lives easier. This workflow we suggest makes choosing which changes to put in a pull request easier, and helps to avoid crazy merge conflicts.
+There are several ways to use Git and {{ cookiecutter.upstream_location }} successfully, and a lot more ways to use them unsuccessfully when working with lots of other people. Here are some best practices that we suggest you use to make your life, and our lives easier. This workflow we suggest makes choosing which changes to put in a pull request easier, and helps to avoid crazy merge conflicts.
 
-First off, follow the [Getting Started](../README.md#getting-started) instructions for setting yourself up to work off of your own fork. The idea here will be to keep `upstream/master`, your local `master` and your `origin/master` all in sync with each other.
+First off, follow the [Getting Started](../README.md#getting-started) instructions for setting yourself up to work from your own fork. The idea here will be to keep `upstream/{{ cookiecutter.default_branch }}`, your local `{{ cookiecutter.default_branch }}` and your `origin/{{ cookiecutter.default_branch }}` all in sync with each other.
 
-Any changes should be made in a separate branch---**not** your `master`---that you push up to your fork. Eventually, when you're ready to submit a PR, you'll do so from the branch that you've been working on. When you push to your `origin/branch_name`, you should get prompted in the terminal by `git` with a URL you can follow to submit a PR. To do so:
+Any changes should be made in a separate branch---**not** your `{{ cookiecutter.default_branch }}`---that you push up to your fork. Eventually, when you're ready to submit a PR, you'll do so from the branch that you've been working on. When you push to your `origin/branch_name`, you should get prompted in the terminal by `git` with a URL you can follow to submit a PR. To do so:
 
-1. Make sure your `master` is up-to-date with upstream `git fetch upstream` and `git merge upstream/master`
+1. Make sure your `{{ cookiecutter.default_branch }}` is up-to-date with upstream `git fetch upstream` and `git merge upstream/{{ cookiecutter.default_branch }}`
 1. Make sure your environment is up-to-date with upstream `make update_environment`
-1. Start your work (from your up-to-date `master`) in a new branch: `git checkout -b my_new_branch`
-1. Commit all your changes to `my_new_branch` (as per the [GitLab Workflow](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet))
+1. Start your work (from your up-to-date `{{ cookiecutter.default_branch }}`) in a new branch: `git checkout -b my_new_branch`
+1. Commit all your changes to `my_new_branch` (as per the [Easydata git Workflow](git-workflow.md))
 
 
-You can pretty much blindly do this by following the [GitLab Workflow](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) religiously.
+You can pretty much blindly do this by following the [Easydata git Workflow](git-workflow.md) religiously.
 
 #### How to submit a PR
 
-1. Push to your GitLab fork by `git push origin my_new_branch`.
-1. If this is the first time you do this from `my_new_branch`, you'll be prompted with a URL from your terminal for how to create a PR. Otherwise, if you go to GitLab, you'll see a yellow banner at the top of the screen prompting you to submit a PR (as long as you're not out of sync with the `upstream master`, in which case, re-sync your branch).
+1. Push to your {{ cookiecutter.upstream_location }} fork by `git push origin my_new_branch`.
+1. If this is the first time you do this from `my_new_branch`, you'll be prompted with a URL from your terminal for how to create a PR. Otherwise, if you go to {{ cookiecutter.upstream_location }}, you'll see a yellow banner at the top of the screen prompting you to submit a PR (as long as you're not out of sync with the `upstream {{ cookiecutter.default_branch }}`, in which case, re-sync your branch).
 1. You have the option to submit a PR in **Draft** status. Select this if you have a work in progress. It disables the ability to merge your PR.
-1. Once you submit your PR, there may be a yellow dot or red X beside your PR. This is because we have tests set up in CircleCI. If you are working in a private repo, you need to authorize access to CircleCI on your fork for tests to run successfully. To do so, follow the link to CircleCI and **authorize gitlab** on your fork of the repo.
+1. Once you submit your PR, there may be a yellow dot or red X beside your PR. This is because we have tests set up in CircleCI. If you are working in a private repo, you need to authorize access to CircleCI on your fork for tests to run successfully. To do so, follow the link to CircleCI and **authorize {{ cookiecutter.upstream_location }}** on your fork of the repo.
 1. When ready, take your PR out of **Draft** status.
 
 
 #### General Git Suggestions:
-* Never commit your changes to your `master` branch. Always work off of a branch. Then you always have a clean local copy of `upstream/master` to work off of.
+* Never commit your changes to your `{{ cookiecutter.default_branch }}` branch. Always work from a branch. Then you always have a clean local copy of `upstream/{{ cookiecutter.default_branch }}` to work from.
 * Stick to **basic git commands** unless you *really* know what you're doing. (e.g. use `add`, `fetch`, `merge`, `commit`, `diff`, `rm`, `mv`)
 * While sometimes convenient, avoid using `git pull` from remotes. Or just general avoid using `git pull`. Use `git fetch` then `git merge` instead.
 * Use `git add -p` instead of `git add` to break up your commits into logical pieces rather than one big snotball of changes.
@@ -106,7 +106,7 @@ In order to make sharing virtual environments easy, the repo includes `make` com
 
 If there's any chance that you added something to the conda environment needed to run your code that was **not** added via your `environment.yml`, [delete your environment, recreate it](conda-environments.md#nuke-it-from-orbit) and then make the appropriate changes to your `environment.yml` file.
 
-Remember to `make update_environment` regularly after fetching and merging the `upstream` remote to keep your conda environment up-to-date with the main repo.
+Remember to `make update_environment` regularly after fetching and merging the `upstream` remote to keep your conda environment up-to-date with the shared (team) repo.
 
 ### Sharing notebooks and code
 We're keen on sharing notebooks for sharing stories and analyses. Best practices can be found in [using notebooks for sharing your analysis](notebooks.md). A short list of reminders:

--- a/{{ cookiecutter.repo_name }}/framework-docs/sharing-your-work.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/sharing-your-work.md
@@ -42,7 +42,7 @@ When you are ready share your notebook or code with others, you'll be able to ti
 - [ ] Share your conda environment. Check in your `environment.yml` file if you've made any changes.
   * If there's any chance that you added something to the conda environment needed to run your code that was **not** added via your `environment.yml` file as per [Setting up and Maintaining your Conda Environment (Reproducibly)](conda-environments.md), [delete your environment and recreate it](conda-environments.md#nuke-it-from-orbit).
 - [ ] *(Optional)* Make sure all tests pass (run `make test`). This will test all of the dataset integration so if you don't have a lot of room on your machine (as it will build all the the datasets if you haven't yet), you may want to skip this step.
-- [ ] At least, make sure all of the tests for your code pass. To subselect your tests you can run `pytest --pyargs src -k your_test_filename`.
+- [ ] At least, make sure all of the tests for your code pass. To subselect your tests you can run `pytest --pyargs {{ cookiecutter.module_name }} -k your_test_filename`.
 
 #### Final Checks
 - [ ] You've [merged the latest version](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) of `upstream/master` into your branch.

--- a/{{ cookiecutter.repo_name }}/framework-docs/troubleshooting.md
+++ b/{{ cookiecutter.repo_name }}/framework-docs/troubleshooting.md
@@ -3,19 +3,19 @@
 It's impossible to test the configurations on every possible machine, so we haven't caught everything. But we're working on making fixes as problems come up. Here's what we've encountered so far (with links to the issues in question if you want to deep dive into the fix).
 
 Before you report a problem, make sure you are running the latest version of the surge repo.
-Assuming you are following the [recommended git workflow](https://github.com/hackalog/cookiecutter-easydata/wiki/Github-Workflow-Cheat-Sheet) (i.e. you have set your `upstream` remote to point to the surge repo, you are working in a branch, and your `master` branch is tracking the surge repo), this means doing a:
+Assuming you are following the [recommended git workflow](git-workflow.md) (i.e. you have set your `upstream` remote to point to the surge repo, you are working in a branch, and your `{{ cookiecutter.default_branch }}` branch is tracking the surge repo), this means doing a:
 ```
-git checkout master
+git checkout {{ cookiecutter.default_branch }}
 git fetch upstream --prune
-git merge upstream/master
-git push origin master
+git merge upstream/{{ cookiecutter.default_branch }}
+git push origin {{ cookiecutter.default_branch }}
 make update_environment
 ```
 
 You can then update your working branches as follows:
 ```
 git checkout my_branch
-git merge master  # advanced git users can do a rebase here. Others please merge.
+git merge {{ cookiecutter.default_branch }}  # advanced git users can do a rebase here. Others please merge.
 ```
 
 Next, turn on debugging in your notebook. Add these cells to the top:

--- a/{{ cookiecutter.repo_name }}/setup.py
+++ b/{{ cookiecutter.repo_name }}/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name='{{ cookiecutter.module_name }}',
     packages=find_packages(),
-    version='0.0.1',
+    version='1.5.0',
     description='''{{ cookiecutter.description }}''',
     author='{{ cookiecutter.author_name }}',
     license='{% if cookiecutter.open_source_license == 'MIT' %}MIT{% elif cookiecutter.open_source_license == 'BSD-2-Clause' %}BSD-2{% endif %}',

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/__init__.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/__init__.py
@@ -2,4 +2,4 @@ from .datasets import *
 from .fetch import *
 from .utils import *
 from .extra import *
-from .add_datasets import *
+from .helpers import *

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/datasets.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/datasets.py
@@ -549,7 +549,7 @@ class Dataset(Bunch):
         if datasource_name not in dsrc_dict:
             raise Exception(f'Unknown Datasource={datasource_name} specified for datset={dataset_name}')
         dsrc = DataSource.from_dict(dsrc_dict[datasource_name])
-        if not dsrc.fetch(fetch_path=fetch_path, force=force):
+        if not dsrc.fetch(fetch_path=fetch_path, force_download=force):
             logger.debug("Fetch failed. Aborting.")
             return None
 
@@ -1228,7 +1228,7 @@ class DataSource(object):
         }
         return dset_opts
 
-    def fetch(self, fetch_path=None, force=False):
+    def fetch(self, fetch_path=None, force_download=False):
         """Fetch files in the `file_dict` to `raw_data_dir` and check hashes.
 
         Parameters
@@ -1236,26 +1236,26 @@ class DataSource(object):
         fetch_path: None or string
             By default, assumes download_dir
 
-        force: Boolean
+        force_download: Boolean
             If True, ignore the cache and re-download the fetch each time
         """
-        if self.fetched_ and force is False:
-            # validate the downloaded files:
-            for filename, item in self.file_dict.items():
-                raw_data_file = paths['raw_data_path'] / filename
-                if not raw_data_file.exists():
-                    logger.warning(f"{raw_data_file.name} missing. Invalidating fetch cache")
-                    self.fetched_ = False
-                    break
-                hash_type = item.get('hash_type', 'sha1')
-                raw_file_hash = hash_file(raw_data_file, algorithm=hash_type)
-                if raw_file_hash != item['hash_value']:
-                    logger.warning(f"{raw_data_file.name} hash invalid ({raw_file_hash} != {item['hash_value']}). Invalidating fetch cache.")
-                    self.fetched_ = False
-                    break
-            else:
-                logger.debug(f'Data Source {self.name} is already fetched. Skipping')
-                return True
+        if self.fetched_ and force_download is False:
+                # validate the downloaded files:
+                for filename, item in self.file_dict.items():
+                    raw_data_file = paths['raw_data_path'] / filename
+                    if not raw_data_file.exists():
+                        logger.warning(f"{raw_data_file.name} missing. Invalidating fetch cache")
+                        self.fetched_ = False
+                        break
+                    hash_type = item.get('hash_type', 'sha1')
+                    raw_file_hash = hash_file(raw_data_file, algorithm=hash_type)
+                    if raw_file_hash != item['hash_value']:
+                        logger.warning(f"{raw_data_file.name} hash invalid ({raw_file_hash} != {item['hash_value']}). Invalidating fetch cache.")
+                        self.fetched_ = False
+                        break
+                else:
+                    logger.debug(f'Data Source {self.name} is already fetched. Skipping')
+                    return True
 
         if fetch_path is None:
             fetch_path = self.download_dir_fq
@@ -1265,15 +1265,20 @@ class DataSource(object):
         self.fetched_ = False
         self.fetched_files_ = []
         self.fetched_ = True
-        for key, item in self.file_dict.items():
-            status, result, hash_value = fetch_file(**item, force=force)
+        for filename, fetch_params in self.file_dict.items():
+            status, result, hash_value = fetch_file(**fetch_params, force=force_download)
             if status:  # True (cached) or HTTP Code (successful download)
-                item['hash_value'] = hash_value
-                item['file_name'] = result.name
+                fetch_params['hash_value'] = hash_value
+
+                # This breaks because file_name should be relative
+                # to raw_data_path
+                #fetch_params['file_name'] = result.name
+                if fetch_params.get('file_name', None) is None:
+                    fetch_params['file_name'] = result.name
                 self.fetched_files_.append(result)
             else:
-                if item.get('fetch_action', False) != 'message':
-                    logger.error(f"fetch of {key} returned: {result}")
+                if fetch_params.get('fetch_action', False) != 'message':
+                    logger.error(f"fetch of {filename} returned: {result}")
                 self.fetched_ = False
 
         self.unpacked_ = False

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/datasets.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/datasets.py
@@ -2062,7 +2062,7 @@ class TransformerGraph:
         for edge in edge_list:
             dsdict = self.process_edge(edge, write_catalog=write_catalog, force=force)
             if dsdict is None:
-                logger.debug("Generation from catalog failed.")
+                logger.error("Generation from catalog failed.")
                 return None
         return dsdict.get(dataset_name, None)
 

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/datasets.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/datasets.py
@@ -1240,22 +1240,22 @@ class DataSource(object):
             If True, ignore the cache and re-download the fetch each time
         """
         if self.fetched_ and force_download is False:
-                # validate the downloaded files:
-                for filename, item in self.file_dict.items():
-                    raw_data_file = paths['raw_data_path'] / filename
-                    if not raw_data_file.exists():
-                        logger.warning(f"{raw_data_file.name} missing. Invalidating fetch cache")
-                        self.fetched_ = False
-                        break
-                    hash_type = item.get('hash_type', 'sha1')
-                    raw_file_hash = hash_file(raw_data_file, algorithm=hash_type)
-                    if raw_file_hash != item['hash_value']:
-                        logger.warning(f"{raw_data_file.name} hash invalid ({raw_file_hash} != {item['hash_value']}). Invalidating fetch cache.")
-                        self.fetched_ = False
-                        break
-                else:
-                    logger.debug(f'Data Source {self.name} is already fetched. Skipping')
-                    return True
+            # validate the downloaded files:
+            for filename, item in self.file_dict.items():
+                raw_data_file = paths['raw_data_path'] / filename
+                if not raw_data_file.exists():
+                    logger.warning(f"{raw_data_file.name} missing. Invalidating fetch cache")
+                    self.fetched_ = False
+                    break
+                hash_type = item.get('hash_type', 'sha1')
+                raw_file_hash = hash_file(raw_data_file, algorithm=hash_type)
+                if raw_file_hash != item['hash_value']:
+                    logger.warning(f"{raw_data_file.name} hash invalid ({raw_file_hash} != {item['hash_value']}). Invalidating fetch cache.")
+                    self.fetched_ = False
+                    break
+            else:
+                logger.debug(f'Data Source {self.name} is already fetched. Skipping')
+                return True
 
         if fetch_path is None:
             fetch_path = self.download_dir_fq

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/datasets.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/datasets.py
@@ -189,7 +189,7 @@ class Dataset(Bunch):
         self['metadata']['dataset_name'] = dataset_name
         self['data'] = data
         self['target'] = target
-        self['extra'] = Extra.from_dict(metadata.get('extra', None))
+        #self['extra'] = Extra.from_dict(metadata.get('extra', None))
         data_hashes = self.get_data_hashes()
 
         if update_hashes:

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/extra.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/extra.py
@@ -74,7 +74,7 @@ def process_extra_files(*, extract_dir=None, metadata=None, unpack_dir=None, fil
             logger.debug(f"Copying files to {extra_dir_fq}...")
 
     file_dict = defaultdict(dict)
-    files = list(unpack_dir.rglob(file_glob))
+    files = sorted(list(unpack_dir.rglob(file_glob)))
     for i, file in enumerate(tqdm(files)):
         if file.is_dir():
             continue

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/fetch.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/fetch.py
@@ -194,7 +194,7 @@ def infer_filename(url=None, file_name=None, source_file=None, **kwargs):
     return file_name
 
 
-def fetch_file(url=None, contents=None,
+def fetch_file(url=None, url_options=None, contents=None,
                file_name=None, dst_dir=None,
                force=False, source_file=None,
                hash_type=None, hash_value=None,
@@ -240,6 +240,8 @@ def fetch_file(url=None, contents=None,
         Text to be displayed to user (if fetch_action == 'message')
     fetch_action: {'copy', 'message', 'url', 'create'}
         Method used to obtain file
+    url_options: dict
+        kwargs to pass when fetching URLs using requests
     file_name:
         output file name. If not specified, use the last
         component of the URL
@@ -271,6 +273,8 @@ def fetch_file(url=None, contents=None,
     '''
     _valid_fetch_actions = ('message', 'copy', 'url', 'create', 'google-drive')
 
+    if url_options is None:
+        url_options = {}
     # infer filename from url or src_path if needed
     if file_name is None:
         file_name = infer_filename(url=url, source_file=source_file)
@@ -337,7 +341,8 @@ def fetch_file(url=None, contents=None,
         # Download the file
         try:
             logger.debug(f"fetching {url}")
-            results = requests.get(url)
+            results = requests.get(url, **url_options)
+            # TODO: change to streaming and use tqdm
             results.raise_for_status()
             raw_file_hash = f"{hash_type}:{_HASH_FUNCTION_MAP[hash_type](results.content).hexdigest()}"
             if hash_value is not None:

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/fetch.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/fetch.py
@@ -10,6 +10,8 @@ import requests
 import joblib
 import gdown
 
+from tqdm.auto import tqdm
+
 from .. import paths
 from ..log import logger
 
@@ -93,6 +95,59 @@ def hash_file(fname, algorithm="sha1", block_size=4096):
         for chunk in iter(lambda: fd.read(block_size), b""):
             hashval.update(chunk)
     return f"{algorithm}:{hashval.hexdigest()}"
+
+def tqdm_download(url, url_options=None, filename=None,
+                  download_path=None,chunk_size=1024):
+    """Download a URL via requests, displaying a tqdm status bar
+
+    Parameters
+    ----------
+    url:
+        URL to download
+    url_options:
+        Options passed to requests.request() for download
+    filename:
+        filename to save. If omitted, it's inferred from the URL
+    download_path: path, default paths['raw_data_path']
+        Inferred filename is relative to this path
+    chunk_size:
+        block size for writes
+
+    Raises
+    ------
+    HTTPError if download fails
+
+    Returns
+    -------
+    filename of written file
+    """
+    if url_options is None:
+        url_options = {}
+    if download_path is None:
+        download_path = paths['raw_data_path']
+    else:
+        download_path = pathlib.Path(download_path)
+    if filename is None:
+        fn = url.split("/")[-1]
+        logger.debug(f"filename not specified. Inferring '{fn}' from url")
+        filename = download_path / fn
+    else:
+        filename = pathlib.Path(filename)
+    resp = requests.get(url, stream=True, **url_options)
+    total = int(resp.headers.get('content-length', 0))
+    with open(filename, 'wb') as file, tqdm(
+            desc=filename.name,
+            total=total,
+            unit='iB',
+            unit_scale=True,
+            unit_divisor=1024,
+    ) as bar:
+        for data in resp.iter_content(chunk_size=chunk_size):
+            size = file.write(data)
+            bar.update(size)
+    resp.raise_for_status()
+
+    return filename
 
 def fetch_files(force=False, dst_dir=None, **kwargs):
     '''
@@ -341,17 +396,14 @@ def fetch_file(url=None, url_options=None, contents=None,
         # Download the file
         try:
             logger.debug(f"fetching {url}")
+            filename = tqdm_download(url, url_options=url_options, filename=raw_data_file)
+            raw_file_hash = hash_file(filename, algorithm=hash_type)
             results = requests.get(url, **url_options)
-            # TODO: change to streaming and use tqdm
-            results.raise_for_status()
-            raw_file_hash = f"{hash_type}:{_HASH_FUNCTION_MAP[hash_type](results.content).hexdigest()}"
             if hash_value is not None:
                 if raw_file_hash != hash_value:
                     logger.error(f"Invalid hash on downloaded {file_name}"
                                  f" {raw_file_hash} != {hash_value}")
                     return False, f"Bad Hash: {raw_file_hash}", None
-            with open(raw_data_file, "wb") as code:
-                code.write(results.content)
         except requests.exceptions.HTTPError as err:
             return False, err, None
     elif fetch_action == 'google-drive':

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/helpers.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/helpers.py
@@ -19,7 +19,8 @@ __all__ = [
 # Create a Dataset from a single csv file
 def dataset_from_csv_manual_download(ds_name, csv_path, download_message,
                                      license_str, descr_str, *, hash_type='sha1',
-                                     hash_value=None,):
+                                     hash_value=None,
+                                     overwrite_catalog=False,):
     """
     Add a dataset to the catalog files where .data is the dataframe from a
     single .csv file obtained via manual download.
@@ -36,8 +37,17 @@ def dataset_from_csv_manual_download(ds_name, csv_path, download_message,
         Contents of metadata license as text
     descr_str:
         Contents of the metadata description as text
+    overwrite_catalog: boolean
+        If True, existing entries in datasets and transformers catalogs will be
+        overwritten
+
+    Returns
+    -------
+    Dataset that was added to the Transformer graph
     """
 
+    if ds_name in dataset_catalog() and not overwrite_catalog:
+        raise KeyError(f"'{ds_name}' already in catalog")
     csv_path = pathlib.Path(csv_path)
     # Create a datasource
     raw_ds_name = ds_name+"_raw"
@@ -104,7 +114,7 @@ def dataset_from_metadata(dataset_name, metadata=None, overwrite_catalog=False):
 
     """
     if dataset_name in dataset_catalog() and not overwrite_catalog:
-        raise KeyError(f"{dataset_name} already in catalog")
+        raise KeyError(f"'{dataset_name}' already in catalog")
     if metadata is None:
         metadata = {}
     dag = TransformerGraph()

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/transformer_functions.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/data/transformer_functions.py
@@ -11,10 +11,32 @@ from ..log import logger
 
 __all__ = [
     'csv_to_pandas',
+    'new_dataset',
     'sklearn_train_test_split',
     'sklearn_transform',
 ]
 
+def new_dataset(dsdict, *, dataset_name, dataset_opts=None):
+    """
+    Transformer function: create a dataset from its default constructor
+
+    Parameters
+    ----------
+    dsdict: ignored
+
+    dataset_name:
+        Name of dataset to create
+    dataset_opts: dict
+        kwargs dict to pass to Dataset constructor
+
+    Returns
+    -------
+    dsdict {dataset_name: Dataset}
+    """
+    if dataset_opts is None:
+        dataset_opts = {}
+    ds = Dataset(dataset_name, **dataset_opts)
+    return {dataset_name: ds}
 
 def sklearn_train_test_split(ds_dict, **split_opts):
     """Transformer Function: performs a train/test split.

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/kvstore.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/kvstore.py
@@ -86,10 +86,7 @@ class KVStore(MutableMapping):
         self.data = dict()
 
         if self._config_file.exists() and not overwrite:
-            self._config.read(self._config_file)
-            if not self._config.has_section(config_section):
-                # File exists but we are adding to a new section of it
-                self._config.add_section(config_section)
+            self._read()
         else:
             self._config.add_section(config_section)
             self._config.read_dict(self.data)
@@ -116,6 +113,12 @@ class KVStore(MutableMapping):
 
     def __len__(self):
         return len(self.data)
+
+    def _read(self):
+        self._config.read(self._config_file)
+        if not self._config.has_section(self._config_section):
+            # File exists but we are adding to a new section of it
+            self._config.add_section(self._config_section)
 
     def _write(self):
         if self._persistent:

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/workflow.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/workflow.py
@@ -32,7 +32,7 @@ from .data import (cached_datasets, dataset_catalog,
                    datasource_catalog, add_datasource, load_catalog, del_from_catalog,
                    process_datasources as make_sources)
 from .data import (transformer_catalog, add_dataset, dataset_from_csv_manual_download,
-                   apply_transforms as make_data)
+                   apply_transforms as make_data, dataset_from_metadata)
 
 __all__ = [
     'add_dataset',
@@ -41,6 +41,7 @@ __all__ = [
     'dataset_catalog',
     'datasource_catalog',
     'dataset_from_csv_manual_download',
+    'dataset_from_metadata',
     'del_from_catalog',
     'load_catalog',
     'make_data',


### PR DESCRIPTION
## We slimmed down the `Makefile`
Easydata has been evolving for a couple of years, and there's a lot of functionality there we don't use every day. We took the opportunity to remove (or at least hide) some of the older workflows in favour of the notebook-and-Dataset approach we've been using lately.

In a future release, we'll look at reviving the "make fetch, make datasets" style targets to use the Dataset dependency graph. In the meantime, these targets are *deprecated*.

## Fetch improvements
One of the most common Easydata tasks is fetching (and hash-validating) raw data from remote sources. We made a couple of improvements to this process:

+ We added a tqdm statusbar to fetch actions. Let's face it. Little blue bars are better than staring at what looks like a hung computer.
+ We added a `url_options` flag for URL-based fetches. Recently, one of our datasets was hosted on a machine with an expired SSL certificate. Since we hash-validate anyway, adding `url_options` let us ignore the SSL errors in our on-disk dataset specification.

## Relative `download_dir`s
In a `DataSource`, `download_dir`, if given without a leading slash, is now assumed to be relative to `raw_data_path`. We expose this fact via a new property (`download_dir_fq`) and make use of it in the `fetch()` mechanisms.

## Better Jupyterhub Integration
We made a number of tweaks and improvements (especially in the
documentation) to better support working on JupyterHub instances. We have big plans here, but for now, we've worked around most jupyterhub issues with better documentation.

## Improved framework documentation.
Speaking of documentation, we spent some time improving the framework (i.e. easydata) documentation, which now includes extensive sections on git configuration and our recommended git workflow.

We also recorded some videos to walk you through the main pieces of the framework.

## New Git Hosting options
Since a recent event was using gitlab, we took the opportunity to add customizable git hosting services (github, gitlab, bitbucket), and  branch names (master vs main), to our cookiecutter template.


## Added new Dataset creation helpers to `src.workflow`
The `src.workflow` namespace is where we put new Easydata features while we're sorting out what the formal API should look like. In 1.5 we added a couple of helper functions that allow for the near instant creation of Datasets under three very common use cases:
  + dataset from a manually downloaded CSV file
  + dataset from metadata/extra information only
  + derived dataset from an existing dataset and a transformation function

## Better handling of local shared data.
We came across an interesting use case recently: a dataset (Malpedia) that was essentially a zipfile full of malware. Needless to say, we didn't want to be building a dataset that downloaded and unpacked these files locally. Instead, we built a Dataset template that contains EXTRA data (raw file hashes) only. By setting `extra_base` to the shared location, this dataset can be used to hash-validate and access raw malware files without the need to ship and unpack a dangerous zipfile.

## New hash algorithm: 'size'
It's not exactly cryptographically secure, but having a file size check in the hash validation arsenal has proved to be very useful. (especially for remote data, where the size "hash" is basically available for free)

## Paths (and local configuration) UX
Easydata uses a dictionary-like mechanism for storing path information; e.g.
```
from src import paths
paths['project_path']
```

Though it looks like a dictionary, there's actually a lot of magic going on under the hood. (To be really nerdy about it, it's a singleton object that is backed by a configparser (.ini) file using the `ExtendedInterpolation` format)

Unfortunately, this turned out to be a dangerous pattern for user UX, as we found users were setting this from notebooks and shared code. paths data is really meant to be local config (and hence changes should not be checked-in to a git repo).

Realizing this, we've modified the implementation to always re-read from the the .ini file when a paths value is queried. We now recommend that paths (and other local configuration info) be used either from the command line; e.g.

```
python -c "import src; src.paths['raw_data_path'] = /path/to/big/data"
```
or by editing `catalog/config.ini` file directly. To help enforce this usage, setting a path will issue a warning when used interactively.

## Dataset Cache changes

We've had to turn off the code paths that attempt to cache **non-dumped** datasets. The thinking was just plain wrong, (the hashes apply to DataSources, and don't contain enough information to cache a full Dataset). To be honest, it's not clear what the benefit would have been anyway.

Datasets are still dumped/cached locally -- i.e. serialized to `data/processed` -- by default, so `Dataset.load()` will always be faster the second time. In the future Easydata releases (currently aiming for 1.6) we will be introducing a new **shared** caching mechanism that speeds up dataset creation within your team or workgroup by caching binary blobs that comprise hashable parts of Datasets.